### PR TITLE
fix: fix Sun icon ray clipping at viewBox edges

### DIFF
--- a/frontend/src/components/common/Icons.tsx
+++ b/frontend/src/components/common/Icons.tsx
@@ -105,15 +105,17 @@ export const CheckCircle = (props: IconProps) => (
 
 export const Sun = (props: IconProps) => (
   <BaseIcon {...props}>
-    <circle cx="12" cy="12" r="5" />
-    <line x1="12" y1="1" x2="12" y2="3" />
-    <line x1="12" y1="21" x2="12" y2="23" />
-    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-    <line x1="1" y1="12" x2="3" y2="12" />
-    <line x1="21" y1="12" x2="23" y2="12" />
-    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    <circle cx="12" cy="12" r="4" />
+    {/* Cardinal rays — pulled inward so stroke never clips */}
+    <line x1="12" y1="2.5" x2="12" y2="5" />
+    <line x1="12" y1="19" x2="12" y2="21.5" />
+    <line x1="2.5" y1="12" x2="5" y2="12" />
+    <line x1="19" y1="12" x2="21.5" y2="12" />
+    {/* Diagonal rays */}
+    <line x1="5.1" y1="5.1" x2="6.8" y2="6.8" />
+    <line x1="17.2" y1="17.2" x2="18.9" y2="18.9" />
+    <line x1="18.9" y1="5.1" x2="17.2" y2="6.8" />
+    <line x1="6.8" y1="17.2" x2="5.1" y2="18.9" />
   </BaseIcon>
 );
 


### PR DESCRIPTION
## Problem
Sun rays were defined with endpoints at x/y=1 and x/y=23 on a 24×24 viewBox. With strokeWidth=2, the stroke was bleeding outside the viewBox and getting clipped by the browser renderer.

## Fix
- Shrunk sun circle radius from 5 → 4 to give rays more room
- Cardinal rays now span 2.5→5 and 19→21.5 (safe inner zone)
- Diagonal rays kept within 5.1–18.9 range
- Consistent with the same fix already applied to prop-and-ferry and country-trivia-web

Zero TypeScript errors (tsc --noEmit).