### PR TITLE
chore: bump node version to 24-alpine LTS

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine
+FROM node:24-alpine
 
 WORKDIR /portfolio-frontend-dev
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,5 +1,5 @@
 # Use official Node.js image to build the frontend
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 
 ENV NODE_OPTIONS="--max-old-space-size=1024"
 


### PR DESCRIPTION
Updates the Node.js base image to the latest active LTS version (24-alpine) across frontend Dockerfiles.