### PR TITLE
fix(docs): remove redundant env copy from manual setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ cd backend
 python -m venv venv
 source venv/bin/activate
 pip install -r dev-requirements.txt
-cp ../env.example .env
 python manage.py migrate
 python manage.py seed_data
 python manage.py runserver


### PR DESCRIPTION
Removes the cp env.example .env step from the manual setup instructions.