### PR TITLE
fix(docker): Correct PostgreSQL 18 volume path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - portfolio-local-db-data:/var/lib/postgresql
+      - portfolio-local-db-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U portfolio-user -d portfolio-db"]
       interval: 5s


### PR DESCRIPTION
Fixes the volume mount path for the postgres container to /var/lib/postgresql/data, preventing permissions/data issues in Postgres 18.