### PR TITLE
fix: ensure trailing slash on bot rewrite for seo blog posts

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -126,7 +126,9 @@ http {
         }
 
         location @bot_backend {
-            rewrite ^/blog/(.*)$ /api/seo/blog/$1 break;
+            # Ensure trailing slash is present to avoid Django 301 redirect
+            rewrite ^/blog/(.*[^/])$ /api/seo/blog/$1/ break;
+            rewrite ^/blog/(.*)/$ /api/seo/blog/$1/ break;
             proxy_pass http://portfolio_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Fixes an issue where the Nginx rewrite rule for bots lacked a trailing slash, causing Django to return a 301 redirect back to the frontend server, resulting in the React default meta tags being served instead of the dynamic blog post meta tags.