### PR TITLE
Fix: Prevent long URLs from overflowing container on mobile

### DIFF
--- a/frontend/src/components/pages/BlogPage.tsx
+++ b/frontend/src/components/pages/BlogPage.tsx
@@ -110,7 +110,7 @@ const BlogPostCard = ({ post }: { post: BlogPost }) => {
         </Link>
 
         <div
-          className="text-sm mb-4 prose prose-sm dark:prose-invert max-w-none line-clamp-4"
+          className="text-sm mb-4 prose prose-sm dark:prose-invert max-w-none line-clamp-4 prose-a:break-words"
           dangerouslySetInnerHTML={{ __html: post.body }}
         />
 

--- a/frontend/src/components/pages/BlogPost.tsx
+++ b/frontend/src/components/pages/BlogPost.tsx
@@ -104,7 +104,7 @@ const BlogPost = () => {
               )}
 
               <div
-                className="prose max-w-none dark:prose-invert"
+                className="prose max-w-none dark:prose-invert prose-a:break-words"
                 dangerouslySetInnerHTML={{ __html: singlePost.body }}
               />
 


### PR DESCRIPTION
Added prose-a:break-words class to blog post containers to ensure long unbroken strings (like URLs) wrap cleanly on mobile screens.