### PR TITLE
fix: Mobile and Wallet Photo Tweaks

### DIFF
--- a/frontend/src/components/pages/BlogPost.tsx
+++ b/frontend/src/components/pages/BlogPost.tsx
@@ -97,14 +97,17 @@ const BlogPost = () => {
               </div>
 
               {singlePost.image_url && (
-                <div className="mb-8 w-full flex justify-center h-64 sm:h-96">
+                <div 
+                  className="mb-8 w-full flex justify-center cursor-pointer"
+                  onClick={() => setLightboxImage(imageUtils.getImageUrl(singlePost.image_url, "blogPost"))}
+                >
                   <img
                     src={imageUtils.getImageUrl(
                       singlePost.image_url,
                       "blogPost",
                     )}
                     alt={singlePost.title}
-                    className="max-w-full max-h-full object-contain rounded-lg"
+                    className="max-w-full h-auto max-h-[70vh] object-contain rounded-lg"
                   />
                 </div>
               )}

--- a/frontend/src/components/pages/BlogPreview.tsx
+++ b/frontend/src/components/pages/BlogPreview.tsx
@@ -102,14 +102,17 @@ const BlogPreview = () => {
               </div>
 
               {singlePost.image_url && (
-                <div className="mb-8 w-full flex justify-center h-64 sm:h-96">
+                <div 
+                  className="mb-8 w-full flex justify-center cursor-pointer"
+                  onClick={() => setLightboxImage(imageUtils.getImageUrl(singlePost.image_url, "blogPost"))}
+                >
                   <img
                     src={imageUtils.getImageUrl(
                       singlePost.image_url,
                       "blogPost",
                     )}
                     alt={singlePost.title}
-                    className="max-w-full max-h-full object-contain rounded-lg"
+                    className="max-w-full h-auto max-h-[70vh] object-contain rounded-lg"
                   />
                 </div>
               )}

--- a/frontend/src/components/sections/Wallet.tsx
+++ b/frontend/src/components/sections/Wallet.tsx
@@ -87,14 +87,14 @@ const CreditCard = ({
 
   return (
     <div
-      className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md hover:scale-[1.02] cursor-pointer flex flex-col"
+      className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md hover:scale-[1.02] cursor-pointer flex flex-col group"
       onClick={onClick}
     >
-      <div className="bg-white dark:bg-neutral-900 w-full aspect-[1.58] p-4 flex items-center justify-center">
+      <div className="bg-transparent flex items-center justify-center w-full aspect-[4/3] overflow-hidden relative">
         <img
           src={thumbnailUrl}
           alt={card.card_name}
-          className="max-w-full max-h-full object-contain"
+          className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
         />
       </div>
       <div className="p-4 flex flex-col flex-grow text-center">


### PR DESCRIPTION
1. Updated wallet cards to use transparent background, aspect-[4/3] ratio, absolute inset-0 object-cover. 2. Made hero image height dynamic via max-h-[70vh] instead of fixed h-64/h-96 so it scales nicely on mobile while preventing extreme heights. 3. Hooked up hero image to the lightbox viewer.