### PR TITLE
fix: Sync Card Theme Transition

### DIFF
--- a/frontend/src/components/common/BlogPostCard.tsx
+++ b/frontend/src/components/common/BlogPostCard.tsx
@@ -17,7 +17,7 @@ export const BlogPostCard = ({ post }: BlogPostCardProps) => {
   });
 
   return (
-    <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md hover:scale-[1.02] md:flex group">
+    <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] md:flex group">
       <div className="md:w-1/3 aspect-[4/3] flex-shrink-0 overflow-hidden relative">
         <img
           src={imageUtils.getImageUrl(post.image_url, "blogCard")}

--- a/frontend/src/components/common/Card.tsx
+++ b/frontend/src/components/common/Card.tsx
@@ -13,7 +13,7 @@ const Card = ({ children, className, onClick, hover = true }: CardProps) => {
     <div
       className={cn(
         "bg-bg-light dark:bg-bg-dark rounded-lg shadow-md overflow-hidden border-2 border-gray-200 dark:border-neutral-800",
-        hover && "transition-all duration-300 hover:shadow-lg",
+        hover && "transition-all duration-200 hover:shadow-lg",
         onClick && "cursor-pointer",
         className,
       )}
@@ -87,7 +87,7 @@ const CardImage = ({
         src={src}
         alt={alt}
         className={cn(
-          "w-full h-full transition-transform duration-300 hover:scale-105",
+          "w-full h-full transition-transform duration-200 hover:scale-105",
           objectFitClasses[objectFit],
         )}
         onError={() => setHasError(true)}

--- a/frontend/src/components/sections/Projects.tsx
+++ b/frontend/src/components/sections/Projects.tsx
@@ -76,7 +76,7 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
   const imageUrl = imageUtils.getImageUrl(project.thumbnail_url, "project");
 
   return (
-    <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md hover:scale-[1.02] group">
+    <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] group">
       <div className="bg-transparent flex items-center justify-center w-full aspect-[4/3] overflow-hidden relative">
         <img
           src={imageUrl}

--- a/frontend/src/components/sections/Wallet.tsx
+++ b/frontend/src/components/sections/Wallet.tsx
@@ -87,7 +87,7 @@ const CreditCard = ({
 
   return (
     <div
-      className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md hover:scale-[1.02] cursor-pointer flex flex-col group"
+      className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] cursor-pointer flex flex-col group"
       onClick={onClick}
     >
       <div className="bg-transparent flex items-center justify-center w-full aspect-[4/3] overflow-hidden relative">


### PR DESCRIPTION
Cards used transition duration 300ms while the root body background used 200ms. This caused a slight visual lag in card borders and backgrounds catching up to the main theme switch. Changed card wrappers to 200ms to perfectly sync with the root.