### PR TITLE
chore: Remove Unused Media Volume

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,7 +35,6 @@ services:
     env_file: .env
     volumes:
       - portfolio_static:/home/backend/django/staticfiles
-      - portfolio_media:/home/backend/django/mediafiles
       - portfolio_logs:/home/backend/django/logs
     user: "backend:backend_group"
     healthcheck:
@@ -76,7 +75,6 @@ services:
         condition: service_healthy
     volumes:
       - portfolio_static:/usr/share/nginx/html/static:ro
-      - portfolio_media:/usr/share/nginx/html/media:ro
       - portfolio_logs:/var/log/nginx
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/nginx-status/"]
@@ -87,8 +85,6 @@ services:
 volumes:
   portfolio_static:
     name: portfolio_static
-  portfolio_media:
-    name: portfolio_media
   portfolio_logs:
     name: portfolio_logs
 


### PR DESCRIPTION
Cleaned up docker-compose.prod.yml to completely remove the portfolio_media volume, since all media assets are now being correctly served from the Cloudflare R2 bucket.