### PR TITLE
fix: Mobile Card Aspect Ratios

### DIFF
--- a/frontend/src/components/common/BlogPostCard.tsx
+++ b/frontend/src/components/common/BlogPostCard.tsx
@@ -18,7 +18,7 @@ export const BlogPostCard = ({ post }: BlogPostCardProps) => {
 
   return (
     <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] md:flex group">
-      <div className="w-full md:w-1/3 aspect-[4/3] flex-shrink-0 overflow-hidden relative">
+      <div className="w-full md:w-1/3 aspect-[16/9] md:aspect-[4/3] flex-shrink-0 overflow-hidden relative">
         <img
           src={imageUtils.getImageUrl(post.image_url, "blogCard")}
           alt={post.title}

--- a/frontend/src/components/sections/Projects.tsx
+++ b/frontend/src/components/sections/Projects.tsx
@@ -77,7 +77,7 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
 
   return (
     <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] group">
-      <div className="bg-transparent flex items-center justify-center w-full aspect-[4/3] overflow-hidden relative">
+      <div className="bg-transparent flex items-center justify-center w-full aspect-[16/9] md:aspect-[4/3] overflow-hidden relative">
         <img
           src={imageUrl}
           alt={project.title || "Project thumbnail"}

--- a/frontend/src/components/sections/Wallet.tsx
+++ b/frontend/src/components/sections/Wallet.tsx
@@ -90,7 +90,7 @@ const CreditCard = ({
       className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] cursor-pointer flex flex-col group"
       onClick={onClick}
     >
-      <div className="bg-transparent flex items-center justify-center w-full aspect-[4/3] overflow-hidden relative">
+      <div className="bg-transparent flex items-center justify-center w-full aspect-[16/9] md:aspect-[4/3] overflow-hidden relative">
         <img
           src={thumbnailUrl}
           alt={card.card_name}


### PR DESCRIPTION
Changed aspect-[4/3] to aspect-[16/9] md:aspect-[4/3] on Blog, Projects, and Wallet cards. This ensures that when the card spans the full width of a mobile screen, the image container becomes a wider banner rather than a giant vertical block, preventing the sides of horizontal photos from getting heavily cropped.