### PR TITLE
fix: Blog Card Image Wrapper

### DIFF
--- a/frontend/src/components/common/BlogPostCard.tsx
+++ b/frontend/src/components/common/BlogPostCard.tsx
@@ -18,7 +18,7 @@ export const BlogPostCard = ({ post }: BlogPostCardProps) => {
 
   return (
     <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] md:flex group">
-      <div className="w-full md:w-1/3 aspect-[4/3] flex-shrink-0 overflow-hidden relative">
+      <div className="bg-transparent flex items-center justify-center w-full md:w-1/3 aspect-[4/3] flex-shrink-0 overflow-hidden relative">
         <img
           src={imageUtils.getImageUrl(post.image_url, "blogCard")}
           alt={post.title}


### PR DESCRIPTION
Applied the exact same background and alignment classes from the Project Card image wrapper (bg-transparent flex items-center justify-center) to the Blog Post Card image wrapper to ensure completely identical rendering on mobile devices.