### PR TITLE
fix: Mobile Card Heights

### DIFF
--- a/frontend/src/components/common/BlogPostCard.tsx
+++ b/frontend/src/components/common/BlogPostCard.tsx
@@ -18,7 +18,7 @@ export const BlogPostCard = ({ post }: BlogPostCardProps) => {
 
   return (
     <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] md:flex group">
-      <div className="bg-transparent flex items-center justify-center w-full md:w-1/3 aspect-[4/3] flex-shrink-0 overflow-hidden relative">
+      <div className="bg-transparent flex items-center justify-center w-full h-40 md:h-auto md:w-1/3 md:aspect-[4/3] flex-shrink-0 overflow-hidden relative">
         <img
           src={imageUtils.getImageUrl(post.image_url, "blogCard")}
           alt={post.title}

--- a/frontend/src/components/sections/Projects.tsx
+++ b/frontend/src/components/sections/Projects.tsx
@@ -77,7 +77,7 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
 
   return (
     <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] group">
-      <div className="bg-transparent flex items-center justify-center w-full aspect-[4/3] overflow-hidden relative">
+      <div className="bg-transparent flex items-center justify-center w-full h-40 overflow-hidden relative">
         <img
           src={imageUrl}
           alt={project.title || "Project thumbnail"}


### PR DESCRIPTION
Reverted the Project Card back to its original h-40 height, and applied the exact same h-40 height to the Blog Post Card on mobile, preserving the custom desktop aspect ratio logic.