### PR TITLE
fix: Native Aspect Ratio on Mobile

### DIFF
--- a/frontend/src/components/common/BlogPostCard.tsx
+++ b/frontend/src/components/common/BlogPostCard.tsx
@@ -18,11 +18,11 @@ export const BlogPostCard = ({ post }: BlogPostCardProps) => {
 
   return (
     <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] md:flex group">
-      <div className="bg-transparent flex items-center justify-center w-full h-40 md:h-auto md:w-1/3 md:aspect-[4/3] flex-shrink-0 overflow-hidden relative">
+      <div className="bg-transparent flex items-center justify-center w-full md:w-1/3 md:aspect-[4/3] flex-shrink-0 overflow-hidden relative">
         <img
           src={imageUtils.getImageUrl(post.image_url, "blogCard")}
           alt={post.title}
-          className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          className="w-full h-auto md:absolute md:inset-0 md:h-full object-cover transition-transform duration-500 group-hover:scale-105"
         />
       </div>
 


### PR DESCRIPTION
Changed the mobile image behavior to use h-auto and native aspect ratios, ensuring the image is never cropped, while perfectly preserving the custom flex object-cover logic on desktop.