### PR TITLE
fix: Restore Project Card Desktop Aspect Ratio

### DIFF
--- a/frontend/src/components/sections/Projects.tsx
+++ b/frontend/src/components/sections/Projects.tsx
@@ -77,7 +77,7 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
 
   return (
     <div className="bg-bg-light dark:bg-bg-dark text-brand-light dark:text-brand-dark border-2 border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden shadow-sm transition-all duration-200 hover:shadow-md hover:scale-[1.02] group">
-      <div className="bg-transparent flex items-center justify-center w-full md:h-40 overflow-hidden relative">
+      <div className="bg-transparent flex items-center justify-center w-full md:aspect-[4/3] overflow-hidden relative">
         <img
           src={imageUrl}
           alt={project.title || "Project thumbnail"}


### PR DESCRIPTION
Restored the md:aspect-[4/3] styling to the Project cards on desktop mode to ensure perfect consistency with the Blog Post and Wallet cards, while preserving the new uncropped dynamic mobile layout.