### PR TITLE
fix: Ensure file pointer resets on WebP conversion fallback

### DIFF
--- a/backend/config/storage.py
+++ b/backend/config/storage.py
@@ -23,6 +23,10 @@ class WebPOptimizedStorage(BaseStorage):
         if ext in ['.jpg', '.jpeg', '.png']:
             try:
                 # Load image into memory with Pillow
+                try:
+                    content.seek(0)
+                except AttributeError:
+                    pass
                 img = Image.open(content)
                 
                 # Prepare output buffer
@@ -46,6 +50,10 @@ class WebPOptimizedStorage(BaseStorage):
                 # Replace the filename extension with .webp
                 name = os.path.splitext(name)[0] + '.webp'
             except Exception as e:
+                try:
+                    content.seek(0)
+                except AttributeError:
+                    pass
                 # If Pillow fails for any reason, safely fall back to the original image
                 pass
                 


### PR DESCRIPTION
Adds `content.seek(0)` to ensure that if a JPEG/PNG is malformed and Pillow rejects it, the original file uploads correctly instead of resulting in a 0-byte file.