### PR TITLE
perf: Defer rendering below-the-fold content to improve TBT

### DIFF
--- a/frontend/src/components/common/LazySection.tsx
+++ b/frontend/src/components/common/LazySection.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState, ReactNode } from "react";
+
+interface LazySectionProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  rootMargin?: string;
+}
+
+export const LazySection = ({ 
+  children, 
+  fallback = <div className="min-h-[50vh]" aria-hidden="true" />, 
+  rootMargin = "200px" 
+}: LazySectionProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // If the browser doesn't support IntersectionObserver, just render it immediately
+    if (!("IntersectionObserver" in window)) {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin }
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => observer.disconnect();
+  }, [rootMargin]);
+
+  return <div ref={ref}>{isVisible ? children : fallback}</div>;
+};

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -3,15 +3,22 @@ import Projects from "../sections/Projects";
 import Blog from "../sections/Blog";
 import Wallet from "../sections/Wallet";
 import Contact from "../sections/Contact";
+import { LazySection } from "../common/LazySection";
 
 const HomePage = () => {
   return (
     <>
       <Bio />
       <Projects limit={3} />
-      <Blog limit={3} />
-      <Wallet limit={4} />
-      <Contact />
+      <LazySection>
+        <Blog limit={3} />
+      </LazySection>
+      <LazySection>
+        <Wallet limit={4} />
+      </LazySection>
+      <LazySection>
+        <Contact />
+      </LazySection>
     </>
   );
 };


### PR DESCRIPTION
Wraps non-critical homepage sections in a LazySection that uses IntersectionObserver. This delays heavy DOM rendering and simultaneous API requests until the user actually scrolls near them, dramatically freeing up the main thread and improving Total Blocking Time (TBT).