### PR TITLE
fix: hardcode VITE_API_URL to /api and remove vault from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Import Secrets from Vault
-        id: vault-secrets
-        uses: hashicorp/vault-action@v3
-        with:
-          url: https://vault.rajivwallace.com
-          method: approle
-          roleId: ${{ secrets.VAULT_PORTFOLIO_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_PORTFOLIO_SECRET_ID }}
-          secrets: |
-            secret/data/portfolio-prod VITE_API_URL | VITE_API_URL ;
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -81,7 +70,7 @@ jobs:
           docker build -t ghcr.io/rajivghandi767/portfolio-frontend:${{ github.run_number }} \
                        -t ghcr.io/rajivghandi767/portfolio-frontend:latest \
                        --label git-commit=${{ steps.git-commit.outputs.short }} \
-                       --build-arg VITE_API_URL=${{ env.VITE_API_URL }} \
+                       --build-arg VITE_API_URL=/api \
                        -f frontend/Dockerfile.prod ./frontend
           docker push ghcr.io/rajivghandi767/portfolio-frontend --all-tags
 


### PR DESCRIPTION
CI runners are public and cannot reach the local homelab Vault.