### PR TITLE
Fix: Hardcode production VITE_API_URL to correct API domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           docker build -t ghcr.io/rajivghandi767/portfolio-frontend:${{ github.run_number }} \
                        -t ghcr.io/rajivghandi767/portfolio-frontend:latest \
                        --label git-commit=${{ steps.git-commit.outputs.short }} \
-                       --build-arg VITE_API_URL=/api \
+                       --build-arg VITE_API_URL=https://portfolio-api.rajivwallace.com \
                        -f frontend/Dockerfile.prod ./frontend
           docker push ghcr.io/rajivghandi767/portfolio-frontend --all-tags
 


### PR DESCRIPTION
Change VITE_API_URL to production API domain in ci.yml