### PR TITLE
chore(ci): remove scheduled cron in favor of centralized orchestrator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
-name: Scheduled Deployment
+name: Deployment Pipeline
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       TAG_TO_DEPLOY:


### PR DESCRIPTION
Removes standalone scheduled cron trigger so deployments are driven by the centralized homelab orchestrator workflow.