### PR TITLE
fix(ci): use python3 zoneinfo for correct EDT timestamp in Discord notifications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Notify Success
         if: success()
         run: |
-          TIMESTAMP=$(TZ='America/New_York' date +'%a, %d %b %Y at %H:%M %Z')
+          TIMESTAMP=$(python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('America/New_York')).strftime('%a, %d %b %Y at %H:%M %Z'))")
           if [ "${{ steps.deploy.outputs.status }}" == "UPDATED" ]; then
               printf -v DESC ":unicorn: **${{ env.APP_NAME }} Update Deployed**\n**:new: New Version Live:**\n• **Tag:** ${{ github.event.inputs.TAG_TO_DEPLOY || 'latest' }}\n• **Backend:** ${{ env.IMAGE_BACKEND }}\n• **Frontend:** ${{ env.IMAGE_FRONTEND }}\n• **Nginx:** ${{ env.IMAGE_NGINX }}\n\n:bar_chart: **Status:** Healthy\n:clock4: **Time:** $TIMESTAMP"
               PAYLOAD=$(jq -n --arg title "🚀 Deployment Successful" \
@@ -154,7 +154,7 @@ jobs:
       - name: Notify Failure
         if: failure()
         run: |
-          TIMESTAMP=$(TZ='America/New_York' date +'%a, %d %b %Y at %H:%M %Z')
+          TIMESTAMP=$(python3 -c "from datetime import datetime; from zoneinfo import ZoneInfo; print(datetime.now(ZoneInfo('America/New_York')).strftime('%a, %d %b %Y at %H:%M %Z'))")
           printf -v DESC ":x: **${{ env.APP_NAME }} Deployment Failed**\n**:warning: Error Details:**\nCheck GitHub Actions logs for run #${{ github.run_number }}.\n:wrench: **Action Required:** Manual intervention needed.\n\n:clock4: **Time:** $TIMESTAMP"
           PAYLOAD=$(jq -n --arg title "🚨 Deployment Alert" \
                           --arg desc "$DESC" \


### PR DESCRIPTION
Replaces the broken `TZ='America/New_York' date` shell trick (which fails silently when tzdata is not in the runner container) with a `python3 -c` zoneinfo call that correctly converts and formats timestamps as EDT/EST regardless of container tzdata availability.